### PR TITLE
fix: Firefox 下无法获取 snapshotId

### DIFF
--- a/src/utils/getSnapshotId.ts
+++ b/src/utils/getSnapshotId.ts
@@ -1,11 +1,29 @@
 import type { RouteLocationNormalized } from 'vue-router';
 import { importIdToSnapshotId } from './indexedDB';
 
+type RouteParams = RouteLocationNormalized['params'];
+
+// 页面上存在多个 [data-v-app]（宿主页面的与本脚本自己注入的），
+// 且本脚本注入的那个没有 vue-router，因此需要挑出真正带 $route 的宿主 app
+const getHostRouteParams = (): RouteParams | undefined => {
+  for (const element of document.querySelectorAll<HTMLElement>('[data-v-app]')) {
+    const route = element.__vue_app__?.config.globalProperties.$route as
+      | RouteLocationNormalized
+      | undefined;
+
+    if (route?.params) return route.params;
+  }
+};
+
+// 注入模式不同时（如 Firefox 的沙箱注入）宿主的 __vue_app__ 不可见，此时回退到解析 URL
+const getPathRouteParams = (): RouteParams => {
+  const [, type, id] = location.pathname.split('/');
+
+  return type === 'import' ? { github_asset_id: id } : { snapshotId: id };
+};
+
 export default async (): Promise<string> => {
-  const app = document.querySelector('.vue-component[data-v-app]') as HTMLDivElement;
-  const appConfig = app.__vue_app__?.config;
-  const route = appConfig?.globalProperties.$route as RouteLocationNormalized;
-  const params = route.params;
+  const params = getHostRouteParams() ?? getPathRouteParams();
 
   if (Object.hasOwn(params, 'snapshotId')) return params.snapshotId as string;
   else return String((await importIdToSnapshotId(Number(params.github_asset_id as string)))!);


### PR DESCRIPTION
getSnapshotId 用 `.vue-component[data-v-app]` 定位宿主页面的 Vue 实例， 但 `.vue-component` 是 hookVue3 靠覆写 window.Proxy 打上的，需要抢在宿主 Vue 挂载之前完成。脚本默认 document-end 注入，Firefox 下抢不到（沙箱注入时更是完全影响不到页面），querySelector 便退而命中脚本自身注入的 app 容器——它没有 vue-router，$route 为 undefined，导致 route.params 抛 TypeError， 「在 VSCode 中打开」等功能静默失效。

改为遍历全部 [data-v-app] 挑出真正带 $route 的宿主 app；取不到时回退解析 location.pathname，覆盖宿主 \_\_vue\_app\_\_ 不可见的沙箱注入场景。